### PR TITLE
Feedback_options is always an array; update docs, API and tests for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/yourusername/thumbsy/workflows/CI/badge.svg)](https://github.com/yourusername/thumbsy/actions)
 
-A Rails gem for adding thumbs up/down voting functionality with comments and feedback options.
+A Rails gem for adding thumbs up/down voting functionality with comments and feedback_options.
 Includes optional JSON API endpoints.
 
 **Note**: This library was created with Claude Sonnet 4, based on the requirements specified in ORIGINAL_PROMPT.txt
@@ -30,15 +30,15 @@ bundle install
 Run the install generator:
 
 ```sh
-# Uses default feedback options (like, dislike, funny)
+# Uses default feedback_options (like, dislike, funny)
 rails generate thumbsy:install
 
-# Or specify custom feedback options
+# Or specify custom feedback_options
 rails generate thumbsy:install --feedback=helpful,unhelpful,spam
 ```
 
 **Note:**
-- The `--feedback` option is **optional**. If omitted, the default feedback options are `like`, `dislike`, and `funny`.
+- The `--feedback` option is **optional**. If omitted, the default feedback_options are `like`, `dislike`, and `funny`.
 - If you pass `--feedback` but do not provide any values (e.g., `--feedback` or `--feedback ""`), the generator will fail with an error.
 
 ## Basic Setup (ActiveRecord only)
@@ -67,13 +67,13 @@ The ID type affects:
 
 ### Custom Feedback Options
 
-You can customize the feedback options when generating the model:
+You can customize the feedback_options when generating the model:
 
 ```bash
-# Use default feedback options (like, dislike, funny)
+# Use default feedback_options (like, dislike, funny)
 rails generate thumbsy:install
 
-# Use custom feedback options
+# Use custom feedback_options
 rails generate thumbsy:install --feedback=helpful,unhelpful,spam
 ```
 
@@ -89,7 +89,7 @@ end
 
 # Usage
 @book.vote_up(@user)
-@book.vote_down(@user, comment: 'Not helpful', feedback_option: 'unhelpful')
+@book.vote_down(@user, comment: 'Not helpful', feedback_options: ['unhelpful'])
 
 # Querying
 @book.votes_count           # Total votes
@@ -99,8 +99,8 @@ end
 Book.with_votes             # Books with votes
 
 # Feedback options
-@book.vote_up(@user, feedback_option: 'helpful')
-@book.vote_down(@user, feedback_option: 'spam')
+@book.vote_up(@user, feedback_options: ['helpful'])
+@book.vote_down(@user, feedback_options: ['spam'])
 ```
 
 ## Optional: JSON API Endpoints
@@ -132,7 +132,7 @@ This adds:
 # Vote up on a post
 curl -X POST /api/v1/books/1/vote_up \
   -H "Authorization: Bearer TOKEN" \
-  -d '{"comment": "Great book!", "feedback_option": "helpful"}'
+  -d '{"comment": "Great book!", "feedback_options": ["helpful"]}'
 
 # Get vote status
 curl -X GET /api/v1/books/1/vote \
@@ -179,7 +179,7 @@ end
 
 ✅ **Comment Support**: Optional comments on every vote
 
-✅ **Feedback Options**: Customizable feedback options (like, dislike, funny, etc.)
+✅ **Feedback Options**: Customizable feedback_options (like, dislike, funny, etc.)
 
 ✅ **Rich Queries**: Comprehensive scopes and helper methods
 
@@ -200,7 +200,7 @@ end
 - Traditional Rails apps with server-rendered views
 - Internal voting systems
 - Simple like/dislike functionality
-- Content moderation with feedback options
+- Content moderation with feedback_options
 
 ### With API
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -69,7 +69,7 @@ GET /books/1/votes
 
 ## API Configuration
 
-Configure the API and feedback options in `config/initializers/thumbsy.rb` (centralized initializer):
+Configure the API and feedback_options in `config/initializers/thumbsy.rb` (centralized initializer):
 
 ```ruby
 Thumbsy.configure do |config|
@@ -172,19 +172,19 @@ end
 ```json
 {
   "comment": "Great book!",
-  "feedback_option": "like"
+  "feedback_options": ["like"]
 }
 ```
 
 **Parameters:**
 - `comment` (optional): Text comment explaining the vote
-- `feedback_option` (optional): One of the configured feedback options (e.g., "like", "dislike", "funny")
+- `feedback_options` (optional): One of the configured feedback_options (e.g., "like", "dislike", "funny")
 
 ## Feedback Options
 
-- `feedback_option` is always a string key (e.g., "like", "dislike").
-- The API and serializer will always return the string value for feedback_option.
-- Invalid feedback options will result in a validation error.
+- `feedback_options` is always a string key (e.g., "like", "dislike").
+- The API and serializer will always return the string value for feedback_options.
+- Invalid feedback_options will result in a validation error.
 
 ## API Responses
 
@@ -196,7 +196,7 @@ end
     "id": 123,
     "vote": true,
     "comment": "Great book!",
-    "feedback_option": "like",
+    "feedback_options": ["like"],
     "voter": {
       "id": 456,
       "name": "John Doe",
@@ -216,7 +216,7 @@ end
     "voted": true,
     "vote_type": "up",
     "comment": "Great book!",
-    "feedback_option": "like",
+    "feedback_options": ["like"],
     "vote_counts": {
       "total": 5,
       "up": 4,
@@ -241,7 +241,7 @@ end
 ```json
 {
   "message": "Validation failed",
-  "errors": ["'invalid_option' is not a valid feedback_option"]
+  "errors": ["'invalid_option' is not a valid feedback_options"]
 }
 ```
 
@@ -257,7 +257,7 @@ end
 
 ```javascript
 // Vote up with comment and feedback
-const voteUp = async (votableType, votableId, comment, feedbackOption) => {
+const voteUp = async (votableType, votableId, comment, feedbackOptions) => {
   const response = await fetch(`/api/v1/${votableType}/${votableId}/vote_up`, {
     method: 'POST',
     headers: {
@@ -266,7 +266,7 @@ const voteUp = async (votableType, votableId, comment, feedbackOption) => {
     },
     body: JSON.stringify({
       comment: comment,
-      feedback_option: feedbackOption
+      feedback_options: feedbackOptions
     })
   });
 
@@ -307,9 +307,9 @@ const useVote = (votableType, votableId) => {
     }
   };
 
-  const voteUp = async (comment, feedbackOption) => {
+  const voteUp = async (comment, feedbackOptions) => {
     try {
-      const data = await voteUp(votableType, votableId, comment, feedbackOption);
+      const data = await voteUp(votableType, votableId, comment, feedbackOptions);
       await fetchVoteStatus(); // Refresh status
       return data;
     } catch (error) {
@@ -318,9 +318,9 @@ const useVote = (votableType, votableId) => {
     }
   };
 
-  const voteDown = async (comment, feedbackOption) => {
+  const voteDown = async (comment, feedbackOptions) => {
     try {
-      const data = await voteDown(votableType, votableId, comment, feedbackOption);
+      const data = await voteDown(votableType, votableId, comment, feedbackOptions);
       await fetchVoteStatus(); // Refresh status
       return data;
     } catch (error) {
@@ -374,9 +374,9 @@ export function useVote(votableType, votableId) {
     }
   };
 
-  const voteUp = async (comment, feedbackOption) => {
+  const voteUp = async (comment, feedbackOptions) => {
     try {
-      const data = await voteUp(votableType, votableId, comment, feedbackOption);
+      const data = await voteUp(votableType, votableId, comment, feedbackOptions);
       await fetchVoteStatus();
       return data;
     } catch (error) {
@@ -446,7 +446,7 @@ The Thumbsy API provides convenient helper methods for common HTTP status codes:
    ```json
    {
      "message": "Validation failed",
-     "errors": ["'invalid_option' is not a valid feedback_option"]
+     "errors": ["'invalid_option' is not a valid feedback_options"]
    }
    ```
 
@@ -477,15 +477,15 @@ The Thumbsy API provides convenient helper methods for common HTTP status codes:
 ### Error Handling in Frontend
 
 ```javascript
-const handleVote = async (action, comment, feedbackOption) => {
+const handleVote = async (action, comment, feedbackOptions) => {
   try {
     setLoading(true);
 
     let response;
     if (action === 'up') {
-      response = await voteUp(comment, feedbackOption);
+      response = await voteUp(comment, feedbackOptions);
     } else if (action === 'down') {
-      response = await voteDown(comment, feedbackOption);
+      response = await voteDown(comment, feedbackOptions);
     } else if (action === 'remove') {
       response = await removeVote();
     }
@@ -531,7 +531,7 @@ const handleVote = async (action, comment, feedbackOption) => {
 
 ### Input Validation
 
-- Validate feedback options against allowed values
+- Validate feedback_options against allowed values
 - Sanitize comment text
 - Rate limiting for vote submissions
 
@@ -559,21 +559,21 @@ RSpec.describe "Thumbsy API" do
   end
 
   describe "POST /books/:id/vote_up" do
-    it "creates a vote with feedback option" do
+    it "creates a vote with feedback_options" do
       post "/books/#{book.id}/vote_up", params: {
         comment: "Great book!",
-        feedback_option: "like"
+        feedback_options: ["like"]
       }
 
       expect(response).to have_http_status(:created)
       json = JSON.parse(response.body)
-      expect(json["data"]["feedback_option"]).to eq("like")
+      expect(json["data"]["feedback_options"]).to eq(["like"])
       expect(json["data"]["comment"]).to eq("Great book!")
     end
 
-    it "rejects invalid feedback options" do
+    it "rejects invalid feedback_options" do
       post "/books/#{book.id}/vote_up", params: {
-        feedback_option: "invalid"
+        feedback_options: ["invalid"]
       }
 
       expect(response).to have_http_status(:unprocessable_entity)
@@ -607,7 +607,7 @@ class Api::V1::CustomVotesController < Thumbsy::Api::ApplicationController
       begin
         vote = @votable.vote_up(current_voter,
                                comment: vote_data[:comment],
-                               feedback_option: vote_data[:feedback_option])
+                               feedback_options: vote_data[:feedback_options])
 
         if vote && vote.persisted?
           results << { id: vote.id, status: "created" }

--- a/lib/generators/thumbsy/templates/create_thumbsy_votes.rb
+++ b/lib/generators/thumbsy/templates/create_thumbsy_votes.rb
@@ -5,9 +5,9 @@ class CreateThumbsyVotes < ActiveRecord::Migration[<%= ActiveRecord::Migration.c
       t.references :voter, null: false, type: :<%= @id_type %>, polymorphic: true, index: false
       t.boolean :vote, null: false, default: false
       t.text :comment
-      <% if defined?(@feedback_options) && @feedback_options.present? %>
-      t.integer :feedback_option
-      <% end %>
+<% if defined?(@feedback_options) && @feedback_options.present? %>
+      t.text :feedback_options, default: <%= [].to_yaml.inspect %>
+<% end %>
       t.timestamps null: false
     end
 

--- a/lib/thumbsy.rb
+++ b/lib/thumbsy.rb
@@ -16,6 +16,10 @@ module Thumbsy
   def self.configure
     self.config ||= Configuration.new
     yield(config)
+    # Ensure feedback_options validation is set up after configuration
+    return unless defined?(ThumbsyVote) && config.feedback_options.present?
+
+    ThumbsyVote.setup_feedback_options_validation!
   end
 
   def self.feedback_options

--- a/lib/thumbsy/api/serializers/vote_serializer.rb
+++ b/lib/thumbsy/api/serializers/vote_serializer.rb
@@ -13,23 +13,12 @@ module Thumbsy
             id: @vote.id,
             vote_type: @vote.up_vote? ? "up" : "down",
             comment: @vote.comment,
-            feedback_option: serialize_feedback_option,
+            feedback_options: @vote.feedback_options || [],
             voter: voter_data(@vote.voter),
           }
         end
 
         private
-
-        def serialize_feedback_option
-          feedback_option = @vote.feedback_option
-          return feedback_option if feedback_option.is_a?(String) || feedback_option.nil?
-
-          # If it's an integer (corrupted enum), use the global feedback options
-          feedback_options = Thumbsy.feedback_options
-          return nil unless feedback_options.is_a?(Array)
-
-          feedback_options[feedback_option] if feedback_option < feedback_options.length
-        end
 
         def voter_data(voter)
           if Thumbsy::Api.voter_serializer

--- a/lib/thumbsy/configuration.rb
+++ b/lib/thumbsy/configuration.rb
@@ -2,10 +2,9 @@
 
 module Thumbsy
   class Configuration
-    attr_accessor :feedback_options, :api_config
+    attr_accessor :api_config
 
     def initialize
-      @feedback_options = nil
       @api_config = Thumbsy::Api::Configuration.new
     end
 
@@ -13,5 +12,13 @@ module Thumbsy
       yield @api_config if block_given?
       @api_config
     end
+
+    def feedback_options=(options)
+      @feedback_options = options
+      # Automatically set up validation if ThumbsyVote is loaded
+      ThumbsyVote.setup_feedback_options_validation! if defined?(ThumbsyVote)
+    end
+
+    attr_reader :feedback_options
   end
 end

--- a/lib/thumbsy/validators/array_inclusion_validator.rb
+++ b/lib/thumbsy/validators/array_inclusion_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Thumbsy
+  class InvalidFeedbackOptionError < ArgumentError; end
+end
+
+module ActiveModel
+  module Validations
+    class ArrayInclusionValidator < EachValidator
+      def validate_each(record, attribute, value)
+        return if value.nil?
+
+        allowed = options[:in] || []
+        return if value.is_a?(Array) && value.all? { |v| allowed.include?(v) }
+
+        record.errors.add(attribute, "contains invalid feedback option(s)")
+      end
+    end
+  end
+end

--- a/lib/thumbsy/votable.rb
+++ b/lib/thumbsy/votable.rb
@@ -12,30 +12,20 @@ module Thumbsy
       scope :with_comments, -> { joins(:thumbsy_votes).where.not(thumbsy_votes: { comment: [nil, ""] }) }
     end
 
-    def vote_up(voter, comment: nil, feedback_option: nil)
+    def vote_up(voter, comment: nil, feedback_options: nil)
       return false if voter && !voter.respond_to?(:thumbsy_votes)
 
-      ThumbsyVote.vote_for(self, voter, true, comment: comment, feedback_option: feedback_option)
-    rescue ActiveRecord::RecordInvalid
-      false
-    rescue ArgumentError => e
-      # Only catch ArgumentError for invalid feedback options, not for nil voters/votables
-      raise e unless e.message.include?("is not a valid feedback_option")
-
-      false
+      ThumbsyVote.vote_for(self, voter, true, comment: comment, feedback_options: feedback_options)
+    rescue ActiveRecord::RecordInvalid => e
+      e.record # Return the invalid vote instance with errors
     end
 
-    def vote_down(voter, comment: nil, feedback_option: nil)
+    def vote_down(voter, comment: nil, feedback_options: nil)
       raise ArgumentError, "Voter is invalid" if voter && !voter.respond_to?(:thumbsy_votes)
 
-      ThumbsyVote.vote_for(self, voter, false, comment: comment, feedback_option: feedback_option)
-    rescue ActiveRecord::RecordInvalid
-      false
-    rescue ArgumentError => e
-      # Only catch ArgumentError for invalid feedback options, not for nil voters/votables
-      raise e unless e.message.include?("is not a valid feedback_option")
-
-      false
+      ThumbsyVote.vote_for(self, voter, false, comment: comment, feedback_options: feedback_options)
+    rescue ActiveRecord::RecordInvalid => e
+      e.record # Return the invalid vote instance with errors
     end
 
     # rubocop:disable Naming/PredicateMethod

--- a/spec/serializers/vote_serializer_spec.rb
+++ b/spec/serializers/vote_serializer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Thumbsy::Api::Serializers::VoteSerializer do
 
   let!(:user) { SerializerTestUser.create!(name: "Serializer User") }
   let!(:book) { SerializerTestBook.create!(title: "Serializer Book") }
-  let(:vote) { book.vote_up(user, comment: "Test vote", feedback_option: "like") }
+  let(:vote) { book.vote_up(user, comment: "Test vote", feedback_options: ["like"]) }
   let(:serializer) { described_class.new(vote) }
 
   describe "#as_json" do
@@ -47,7 +47,7 @@ RSpec.describe Thumbsy::Api::Serializers::VoteSerializer do
         id: vote.id,
         vote_type: "up",
         comment: "Test vote",
-        feedback_option: "like",
+        feedback_options: ["like"],
       )
 
       # Verify timestamps are NOT included
@@ -78,18 +78,18 @@ RSpec.describe Thumbsy::Api::Serializers::VoteSerializer do
     end
 
     it "handles down votes correctly" do
-      down_vote = book.vote_down(user, comment: "Down vote", feedback_option: "dislike")
+      down_vote = book.vote_down(user, comment: "Down vote", feedback_options: ["dislike"])
       serializer = described_class.new(down_vote)
       result = serializer.as_json
 
       expect(result).to include(
         vote_type: "down",
         comment: "Down vote",
-        feedback_option: "dislike",
+        feedback_options: ["dislike"],
       )
     end
 
-    it "handles votes without comment and feedback_option" do
+    it "handles votes without comment and feedback_options" do
       vote_without_optional = book.vote_up(user)
       serializer = described_class.new(vote_without_optional)
 
@@ -98,7 +98,7 @@ RSpec.describe Thumbsy::Api::Serializers::VoteSerializer do
       expect(result).to include(
         vote_type: "up",
         comment: nil,
-        feedback_option: nil,
+        feedback_options: [],
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define do
     t.references :voter, null: false, polymorphic: true, index: true
     t.boolean :vote, null: false
     t.text :comment
-    t.integer :feedback_option
+    t.text :feedback_options, default: "--- []\n"
     t.timestamps null: false
 
     t.index %i[voter_type voter_id votable_type votable_id],
@@ -86,6 +86,14 @@ require_relative "../lib/thumbsy/models/thumbsy_vote"
 ActiveRecord::Base.extend(Thumbsy::Extension)
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    # Ensure feedback_options column exists for tests
+    unless ActiveRecord::Base.connection.column_exists?(:thumbsy_votes, :feedback_options)
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migration.add_column :thumbsy_votes, :feedback_options, :text
+      end
+    end
+  end
   # Set up Thumbsy config for tests
   Thumbsy.configure do |c|
     c.feedback_options = %w[like dislike funny]


### PR DESCRIPTION
Update to have `feedback_options` as an array instead of `feedback_option` as an enum, which way less flexible in the long term 